### PR TITLE
Add system dependencies for CI build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,8 +17,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install system libraries
-      run: sudo apt-get update && sudo apt-get install -y \
-           pkg-config libfreetype6-dev libfontconfig1-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y pkg-config libfreetype6-dev libfontconfig1-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install system libraries
+      run: sudo apt-get update && sudo apt-get install -y \
+           pkg-config libfreetype6-dev libfontconfig1-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
## Summary
- install freetype and fontconfig development packages in the Rust workflow so font-kit can compile on CI

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f9da6d8898832bb0b2cbdc2bfc24c8